### PR TITLE
Make building easier with a Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,10 @@ BINDIR ?= $(PREFIX)/bin
 SRC  := bindump.c clz.c dsc_syms.c rand.c vmacho.c xref.c
 BINS := bindump clz dsc_syms mesu strerror rand vmacho xref
 
-all: $(SRC:%.c=%)
+all: $(SRC:%.c=%) mesu strerror
 
 %: %.c
 	$(CC) $(CFLAGS) $@.c -o $@ $(LDFLAGS)
-	$(FAKEROOT) chmod +x $@
 
 mesu: mesu.c
 	$(CC) $(CFLAGS) $@.c -o $@ -framework CoreFoundation $(LDFLAGS)
@@ -22,6 +21,7 @@ strerror: strerror.c
 		-framework CoreFoundation -framework Security
 
 install: $(SRC:%.c=%) mesu strerror
+	$(FAKEROOT) chmod +x $^
 	mkdir -p $(DESTDIR)$(BINDIR)
 	cp -a $^ $(DESTDIR)$(BINDIR)
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+CC       ?= cc
+FAKEROOT ?= fakeroot
+CFLAGS   ?= -Wall -O3
+
+PREFIX ?= /usr/local
+BINDIR ?= $(PREFIX)/bin
+
+SRC := bindump.c clz.c dsc_syms.c rand.c vmacho.c xref.c
+
+all: $(SRC:%.c=%)
+
+%: %.c
+	$(CC) $(CFLAGS) $@.c -o $@ $(LDFLAGS)
+	$(FAKEROOT) chmod +x $@
+
+mesu: mesu.c
+	$(CC) $(CFLAGS) $@.c -o $@ -framework CoreFoundation $(LDFLAGS)
+
+strerror: strerror.c
+	$(CC) $(CFLAGS) $@.c -o $@ $(LDFLAGS) \
+		-framework CoreFoundation -framework Security
+
+install: $(SRC:%.c=%)
+	mkdir -p $(DESTDIR)$(BINDIR)
+	cp -a $^ $(DESTDIR)$(BINDIR)
+
+.PHONY: $(SRC) install

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC       ?= cc
-FAKEROOT ?= fakeroot
+INSTALL  ?= install
 CFLAGS   ?= -Wall -O3
 
 PREFIX ?= /usr/local
@@ -20,10 +20,8 @@ strerror: strerror.c
 	$(CC) $(CFLAGS) $@.c -o $@ $(LDFLAGS) \
 		-framework CoreFoundation -framework Security
 
-install: $(SRC:%.c=%) mesu strerror
-	$(FAKEROOT) chmod +x $^
-	mkdir -p $(DESTDIR)$(BINDIR)
-	cp -a $^ $(DESTDIR)$(BINDIR)
+install: all
+	$(INSTALL) -Dm755 $(BINS) $(DESTDIR)$(BINDIR)
 
 clean:
 	rm -r $(BINS)
@@ -31,4 +29,4 @@ clean:
 uninstall: clean
 	rm -rf $(addprefix $(DESTDIR)$(BINDIR)/, $(BINS))
 
-.PHONY: mesu strerror clean install
+.PHONY: all clean install

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ CFLAGS   ?= -Wall -O3
 PREFIX ?= /usr/local
 BINDIR ?= $(PREFIX)/bin
 
-SRC := bindump.c clz.c dsc_syms.c rand.c vmacho.c xref.c
+SRC  := bindump.c clz.c dsc_syms.c rand.c vmacho.c xref.c
+BINS := bindump clz dsc_syms mesu strerror rand vmacho xref
 
 all: $(SRC:%.c=%)
 
@@ -20,8 +21,14 @@ strerror: strerror.c
 	$(CC) $(CFLAGS) $@.c -o $@ $(LDFLAGS) \
 		-framework CoreFoundation -framework Security
 
-install: $(SRC:%.c=%)
+install: $(SRC:%.c=%) mesu strerror
 	mkdir -p $(DESTDIR)$(BINDIR)
 	cp -a $^ $(DESTDIR)$(BINDIR)
 
-.PHONY: $(SRC) install
+clean:
+	rm -r $(BINS)
+
+uninstall: clean
+	rm -rf $(addprefix $(DESTDIR)$(BINDIR)/, $(BINS))
+
+.PHONY: mesu strerror clean install


### PR DESCRIPTION
This small PR makes building projects easier by adding a Makefile; all projects in the repository can be compiled by running `make` in the project directory. Specific changes have been documented under the commit message. 