### PR TITLE
Makefile: Add BSD `install` compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
 .DS_Store
-bindump
-clz
-dsc_syms
-mesu
-rand
-strerror
-vmacho
-xref
+/bindump
+/clz
+/dsc_syms
+/mesu
+/rand
+/strerror
+/vmacho
+/xref

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
 .DS_Store
-/bindump
-/clz
-/dsc_syms
-/mesu
-/rand
-/strerror
-/vmacho
-/xref
+bindump
+clz
+dsc_syms
+mesu
+rand
+strerror
+vmacho
+xref

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ all: $(BINS)
 	$(CC) $(CFLAGS) $< -o $@ $($@_CFLAGS) $(LDFLAGS)
 
 install: all
-	$(INSTALL) -Dm755 $(BINS) -t $(DESTDIR)$(BINDIR)
+	$(INSTALL) -d $(DESTDIR)$(BINDIR)
+	$(INSTALL) -m755 $(BINS) $(DESTDIR)$(BINDIR)
 
 clean:
 	rm -r $(BINS)


### PR DESCRIPTION
This pull request adds BSD `install` compatibility to the Makefile.

GNU `install` and BSD `install` are finicky when it comes to command line options. This is the middle ground where both are supported. This allows the bundled version of `install` in macOS to be used.